### PR TITLE
docs: update license to AGPL-3 and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,70 +1,170 @@
-# Contributing to Pacte Xat
+# Contributing to Aipacto
 
-Thank you for your interest in contributing to Pacte Xat! This guide will help you get started and understand our development workflow and requirements.
+Thank you for your interest in contributing to Aipacto! We're building an AI-driven Operating System for city councils and local governments, starting with a revolutionary tender writer application for Spanish municipalities. This guide will help you get started and understand our development workflow and requirements.
 
 ## Prerequisites
 
-- **Node.js**: v22 or higher
-- **Yarn**: v4 or higher (we use [Yarn v4](https://yarnpkg.com/) in node-modules mode)
-- **TypeScript**: All code is written in TypeScript (v5.7+)
+- **Nix** (for reproducible development environment)
+  - **Recommended:** [Determinate Systems Nix Installer](https://zero-to-nix.com/start/install/) (single command, works on Linux/macOS/WSL)
+  - **Alternative:** [Official NixOS installer](https://nixos.org/download.html)
 
-You can check your versions with:
+  Nix ensures everyone uses the exact same versions of Node.js, Yarn, TypeScript, and other tools. No more "works on my machine" issues!
 
-```sh
-node --version
-yarn --version
-```
+- **Watchman** (for file watching and hot reloading)
+  - **Linux:** Install using [Homebrew](https://brew.sh/):
+
+    ```bash
+    # Install Homebrew for Linux if you don't have it
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+    # Install Watchman
+    brew install watchman
+    ```
+
+  - **macOS:** `brew install watchman`
+  - **Windows:** Download from [Watchman releases](https://github.com/facebook/watchman/releases)
+  
+  Watchman improves file watching performance and is required for optimal development experience with hot reloading.
+
+## Getting Started
+
+1. **Install Nix:**
+   - **Recommended:** Use the [Determinate Systems Nix Installer](https://zero-to-nix.com/start/install/) for the best experience
+   - **Alternative:** Follow the [official NixOS guide](https://nixos.org/download.html) if you prefer the traditional installer
+
+2. **Enter the development shell:**
+   In the project root, run:
+
+   ```bash
+   nix develop
+   ```
+
+   This will drop you into a shell with the correct Node.js, Yarn, TypeScript, and all required tools.
+
+3. **Install dependencies:**
+
+   ```bash
+   yarn install
+   ```
+
+4. **Run the applications:**
+
+   Start the backend server (handles AI agents and tender data processing):
+
+   ```bash
+   yarn workspace @aipacto/apps-server dev
+   ```
+
+   Start the tender writer web application:
+
+   ```bash
+   yarn workspace @aipacto/apps-expo start
+   ```
+
+> **Note:** All commands below assume you are inside the Nix dev shell (`nix develop`).
 
 ## Monorepo Structure & Workspaces
 
-Pacte Xat uses a monorepo managed with Yarn workspaces. Each package/app has its own scripts. To run scripts for a specific package, use:
+Aipacto uses a monorepo managed with Yarn workspaces, organized around our tender writer application and municipal AI system. Each package/app has its own scripts. To run scripts for a specific package, use:
 
 ```sh
 yarn workspace <package> <script>
 ```
 
-**Examples:**
+**Key Workspaces:**
 
-- Start the Expo app (web/native):
+- **Tender Writer Application**: Cross-platform interface for creating procurement documents
 
   ```sh
   yarn workspace @aipacto/apps-expo start
   ```
 
-- Start the Fastify server:
+- **Municipal AI Server**: Backend handling Spanish tender data crawling and AI processing
 
   ```sh
-  yarn workspace @aipacto/apps-server start
+  yarn workspace @aipacto/apps-server dev
   ```
 
-- Build a shared package:
+- **Shared Procurement Components**: UI components optimized for municipal workflows
 
   ```sh
   yarn workspace @aipacto/shared-ui-core build
   ```
 
+## Contributing & PR Workflow
+
+- **Branching:**
+  - Never commit or push directly to `main`. Use feature branches and open a Pull Request (PR).
+- **PR Types:**
+  - Use **Draft PRs** for work-in-progress (WIP). Mark as "Ready for review" when complete.
+  - Only **squash** or **rebase** merges are allowed (no merge commits).
+- **CI/CD:**
+  - GitHub Actions will run for all non-draft PRs and pushes to `main`.
+  - Draft PRs will skip CI until marked ready.
+- **Pre-commit hooks:**
+  - Managed by Lefthook. Run checks for lint, types, secrets, and dependency consistency.
+
+### Local Enforcement of Merge Policy
+
+- **No direct commits or pushes to `main` are allowed.**  
+  Our hooks will block any attempt to commit or push directly to the `main` branch.
+
+- **On feature branches:**
+  - **Before every commit** the following quick checks run automatically:
+    - Lint (`yarn lint`)
+    - Dependency consistency (`yarn check-deps`)
+    - Secret scan of staged files (`yarn secretlint`)
+  - **Before every push** additional enforcement runs:
+    - Blocks direct pushes to `main` branch
+    - Blocks merge commits to `main` branch (only rebase/squash allowed)
+  - You can commit and push freely on feature branches. Heavy checks (type-checking, build, etc.) run in CI when you open a PR.
+  - **Tip:** Use rebase or squash when your work is ready, then push and create a Pull Request.
+
 ## Pre-commit Checks
 
 When you commit staged files, several automated checks will run (see `lefthook.yml`):
 
-- **Linting**: Code style and formatting
-- **Dependency Version Consistency**: Ensures all packages use compatible versions
-- **Type Checking**: Validates TypeScript types
-- **Secret Scanning**: Prevents committing secrets
-- **Path Generation**: Updates TypeScript path mappings
+- **Block Main Commits**: Prevents direct commits to `main` branch
+- **Linting**: Code style and formatting (`yarn lint`)
+- **Dependency Version Consistency**: Ensures all packages use compatible versions (`yarn check-deps`)
+- **Secret Scanning**: Prevents committing secrets (`yarn secretlint` on staged files)
 
 If any check fails, your commit will be blocked. **You must fix all errors before committing.**
 
+## Pre-push Checks
+
+Additional checks run before pushing:
+
+- **Block Main Push**: Prevents direct pushes to `main` branch
+- **Block Merge Commits**: Prevents merge commits to `main` (enforces rebase/squash)
+
 ## Coding Standards
 
-- Follow Clean Architecture and DDD principles (bounded contexts)
+- Follow Clean Architecture and DDD principles (bounded contexts for procurement, municipal data, AI agents)
 - Use TypeScript for all code (frontend and backend)
-- For UI: Use Tamagui, Material Design 3, and custom tokens from `@aipacto/shared-ui-core/theme`
-- Add new UI text to the appropriate i18n files (e.g., `common.json`)
-- Prefer start/end over left/right for layout (LTR/RTL support)
-- Apply accessibility best practices
+- For UI: Use Tamagui, Material Design 3, and custom tokens optimized for municipal interfaces
+- Add new UI text to appropriate i18n files (Spanish/Catalan support for `common.json`)
+- Prefer start/end over left/right for layout (LTR support, future RTL compatibility)
+- Apply accessibility best practices (WCAG 2.1 AA for public sector compliance)
 - Keep code and comments clear and concise
+- Document public APIs with JSDoc, especially for tender processing functions
+
+## CI & Quality
+
+- **Build:** `yarn build`
+- **Lint:** `yarn lint`
+- **Type Check:** `yarn check-types`
+- **Secrets:** `yarn check-secrets`
+- **Dependencies versioning:** `yarn check-deps`
+
+## Domain Knowledge
+
+Contributing to Aipacto benefits from understanding:
+
+- **Spanish Public Procurement**: Familiarity with LCSP (Ley de Contratos del Sector Público) and PLACSP portal
+- **Municipal Operations**: Understanding of city council workflows and administrative processes
+- **AI/LLM Integration**: Experience with LangChain, document processing, or Spanish language models
 
 ## Questions?
 
-Feel free to open an issue or discussion on GitHub if you have questions or need help getting started!
+Feel free to open an issue or discussion on GitHub if you have questions about contributing to Spain's municipal AI revolution!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,30 +1,661 @@
-MIT License with Visible Attribution Clause
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2024 AIPacto.com
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-1. The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-2. Any public-facing deployment or distribution of the Software, including
-   but not limited to websites, mobile apps, user interfaces, or publicly
-   accessible services using substantial portions of the Software, must
-   provide clearly visible attribution to the original project, such as:
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-      "Powered by AIPacto.com"
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-   This attribution must be placed in a user-visible location.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -4,69 +4,75 @@
 
 ## Vision & Mission
 
-Aipacto is an open-source, AI-powered chat platform designed to revolutionize decision-making and transparency in local and regional governments. Our vision is to set a new global standard for AI in politics and governance, starting with Catalan-speaking regions and expanding internationally. By leveraging advanced language models (like Aina Kit's Salamandra-7b-instruct), we empower public administrations and citizens with data-driven insights and accessible civic engagement tools.
+Aipacto is an open-source, AI-driven Operating System designed to revolutionize efficiency and transparency in city councils and local governments. Our vision is to set a new global standard for AI in public administration, starting in Spain and expanding internationally. By leveraging advanced language models and comprehensive data integration, we empower local governments with intelligent tools that streamline operations and enhance public service delivery.
 
 ### Why Aipacto?
 
-- **Empower Local Decision-Making**: Provide local governments with tools to analyze regional data and plan effectively, outperforming centralized systems by focusing on hyper-local context.
-- **Enhance Transparency & Access**: Make complex information accessible and actionable for citizens, fostering trust and participation.
-- **Scalable & Sustainable**: Designed for international adaptation, with a free self-hosted version and a paid cloud subscription for long-term viability.
+- **Streamline Public Operations**: Automate and optimize complex administrative processes, reducing bureaucracy and improving efficiency.
+- **Data-Driven Governance**: Transform vast amounts of public data into actionable insights for better decision-making.
+- **Scalable & Sustainable**: Designed for municipalities of all sizes, with a free self-hosted version and enterprise cloud solutions for long-term viability.
 
-### Example Use Cases
+### First Application: AI-Powered Tender Writer
 
-**For Citizens:**
+Our flagship application revolutionizes public procurement by leveraging comprehensive data from Spanish governmental tender portals:
 
-- "What did the city council decide about the new equality plan in the last meeting?"
-- "Where can I find information on local cultural events and their economic impact?"
-- "How do I report a broken streetlamp in my neighborhood?"
-- "Explain the Municipal Action Plan in simple terms."
-- "What is the city doing to address the perception that 'nothing ever happens here'?"
+**For Procurement Officers:**
 
-**For Government Officials & Staff:**
+- "Generate a complete tender document for road maintenance services based on similar successful tenders"
+- "Analyze market pricing trends for IT services in municipalities of similar size"
+- "Create technical specifications for urban lighting projects using best practices from other cities"
+- "Draft evaluation criteria that comply with Spanish public procurement law"
 
-- "Generate a draft social media thread summarizing the last council meeting."
-- "Identify strengths and weaknesses in the opposition's arguments."
-- "Summarize citizen complaints about street cleaning."
-- "Analyze a large planning document and extract the 5 most relevant points."
-- "Identify mentions of 'economic impact' and 'sustainability' in festival reports."
+**For Municipal Staff:**
+
+- "Find similar tenders from other councils for waste management contracts"
+- "Analyze tender requirements and suggest improvements based on successful awards"
+- "Generate procurement timelines that comply with legal requirements"
+- "Create budget justifications using comparable municipal data"
+
+**Key Features:**
+
+- **Comprehensive Data Integration**: Accesses all published tenders from Spanish governmental portals (PLACSP, regional platforms)
+- **Intelligent Document Generation**: Creates compliant tender documents using successful templates
+- **Market Intelligence**: Provides pricing insights and vendor analysis
+- **Legal Compliance**: Ensures all documents meet Spanish procurement regulations
 
 ### Economic & Social Impact
 
-- **Catalonia**: 900+ municipalities, €8B+ annual budget. Even 5% adoption could support €400M+ in managed resources.
-- **Efficiency Gains**: 2-5% savings in operational budgets, potentially €8-20M optimized annually in early stages.
-- **Scalability**: Designed for Spain (8,000+ municipalities, €60B budget) and beyond, with plans for multilingual support.
+- **Spain**: 8,000+ municipalities managing €60B+ in annual procurement. Even 5% adoption could optimize €3B+ in public spending.
+- **Procurement Efficiency**: Reduce tender preparation time by 70% while improving quality and compliance.
+- **Market Intelligence**: Enable better pricing negotiations, potentially saving 2-5% on municipal contracts.
+- **Scalability**: Starting in Spain with plans for EU expansion, leveraging multilingual AI capabilities.
 
 ## Architecture & Tech Stack
 
-Aipacto is built with a modern, robust architecture:
+Aipacto is built with a modern, enterprise-grade architecture:
 
-- **Clean Architecture & DDD**: The codebase is organized into bounded contexts, following Clean Architecture and Domain-Driven Design principles for maintainability and scalability.
-- **TypeScript Everywhere**: Full stack, cross-platform development in TypeScript for consistency and safety.
-- **Frontend**: React, React Native, Expo, Tamagui (Material Design 3, custom tokens for theming).
-- **Backend**: Fastify (Node.js), Effect, containerized for secure computation.
-- **AI Orchestration**: LangChain, LangGraph for multi-agent workflows.
-- **Semantic Search**: Qdrant.
-- **Core LLMs**: Aina Kit's Salamandra models, with support for OpenAI, DeepSeek, Grok, etc.
-- **Data Storage**: PostgreSQL, Databricks.
-- **Other Tools**: Mass data processing, internet search, GitHub for open-source collaboration.
+- **Clean Architecture & DDD**: Organized into bounded contexts following Clean Architecture and Domain-Driven Design for maintainability and scalability.
+- **TypeScript Everywhere**: Full-stack development in TypeScript for consistency, safety, and developer productivity.
+- **Frontend**: React, React Native, Expo with Tamagui (Material Design 3) for cross-platform municipal applications.
+- **Backend**: Fastify (Node.js), Effect for functional programming, containerized for secure multi-tenant deployment.
+- **AI Orchestration**: LangChain, LangGraph for multi-agent workflows processing tender documents and procurement data.
+- **Data Integration**: Comprehensive crawlers for Spanish governmental tender portals (PLACSP, regional platforms).
+- **Search & Analytics**: Qdrant for semantic search across tender documents, PostgreSQL for structured data.
+- **LLM Support**: Spanish-optimized models with fallback to OpenAI, Claude, and other providers.
+- **Security & Compliance**: Built for public sector requirements with audit trails and data protection.
 
 ## Core Components
 
-1. **Chat Interface**: Cross-platform (web/mobile) chat UI for users to query data, generate insights, or request actions.
-2. **Data Crawlers**: Scripts to collect and structure regional data for analysis.
-3. **Agentic Workflows**: Multi-agent system orchestrated via LangChain and LangGraph.
-4. **Backend APIs**: Fastify server managing chat sessions, data processing, and agent tasks.
+1. **Tender Writer Interface**: Cross-platform (web/mobile) application for creating and managing procurement documents.
+2. **Spanish Tender Data Crawlers**: Automated scripts to collect and structure tender data from governmental portals.
+3. **Procurement AI Agents**: Multi-agent system specialized in tender analysis, document generation, and compliance checking.
+4. **Municipal APIs**: Fastify server managing procurement workflows, document processing, and tender intelligence.
 
 ## Getting Involved
 
-We are actively developing the core web and mobile interfaces and the AI agent orchestrator. If you're interested in making a significant impact at the intersection of AI, governance, and open source, we'd love to have you contribute!
+We are actively developing the tender writer application and AI procurement agents. If you're interested in revolutionizing public procurement through AI and making municipal operations more efficient, we'd love to have you contribute!
 
 Before you start, please read our [Contributing Guide](./CONTRIBUTING.md) for setup instructions, coding standards, and contribution workflow.
 
 ## License
 
-Licensed under the MIT License with a visible attribution clause.
-
-Any public use must display the text "Powered by AIPacto.com".
+Licensed under the GNU Affero General Public License v3.0.
 
 See [LICENSE](./LICENSE) for full details.

--- a/docs/README_es.md
+++ b/docs/README_es.md
@@ -1,72 +1,78 @@
 # Aipacto
 
-**Inglés**: Para la versión en inglés de este README, consulta [`README`](../README.md).
+**English**: For the English version of this README, see [`README.md`](../README.md).
 
 ## Visión y Misión
 
-Aipacto es una plataforma de chat de código abierto impulsada por IA, diseñada para revolucionar la toma de decisiones y la transparencia en gobiernos locales y regionales. Nuestra visión es establecer un nuevo estándar global para la IA en la política y la gobernanza, comenzando por las regiones de habla catalana y expandiéndose internacionalmente. Aprovechando modelos de lenguaje avanzados (como Salamandra-7b-instruct de Aina Kit), empoderamos a las administraciones públicas y a la ciudadanía con información basada en datos y herramientas accesibles para la participación cívica.
+Aipacto es un Sistema Operativo de código abierto, impulsado por IA y diseñado para revolucionar la eficiencia y la transparencia en ayuntamientos y gobiernos locales. Nuestra visión es establecer un nuevo estándar mundial para la IA en la administración pública, comenzando en España y expandiéndonos internacionalmente. Aprovechando modelos de lenguaje avanzados y una integración de datos exhaustiva, empoderamos a los gobiernos locales con herramientas inteligentes que optimizan las operaciones y mejoran la prestación de servicios públicos.
 
 ### ¿Por qué Aipacto?
 
-- **Potenciar la toma de decisiones local**: Proporcionar a los gobiernos locales herramientas para analizar datos regionales y planificar eficazmente, superando a los sistemas centralizados al centrarse en el contexto hiperlocal.
-- **Mejorar la transparencia y el acceso**: Hacer que la información compleja sea accesible y accionable para la ciudadanía, fomentando la confianza y la participación.
-- **Escalable y sostenible**: Diseñado para adaptarse internacionalmente, con una versión autoalojada gratuita y una suscripción en la nube para la viabilidad a largo plazo.
+- **Optimizar las Operaciones Públicas**: Automatizar y optimizar procesos administrativos complejos, reduciendo la burocracia y mejorando la eficiencia.
+- **Gobernanza Basada en Datos**: Transformar grandes volúmenes de datos públicos en información accionable para una mejor toma de decisiones.
+- **Escalable y Sostenible**: Diseñado para municipios de todos los tamaños, con una versión gratuita autoalojada y soluciones empresariales en la nube para una viabilidad a largo plazo.
 
-### Casos de uso
+### Primera Aplicación: Generador de Licitaciones Impulsado por IA
 
-**Para la ciudadanía:**
+Nuestra aplicación insignia revoluciona la contratación pública aprovechando datos exhaustivos de los portales de licitación gubernamentales de España:
 
-- "¿Qué decidió el ayuntamiento sobre el nuevo plan de igualdad en la última reunión?"
-- "¿Dónde puedo encontrar información sobre eventos culturales locales y su impacto económico?"
-- "¿Cómo reporto una farola rota en mi barrio?"
-- "Explica el Plan de Acción Municipal en términos sencillos."
-- "¿Qué está haciendo el ayuntamiento para abordar la percepción de que 'aquí nunca pasa nada'?"
+**Para Técnicos de Contratación:**
 
-**Para personal y cargos públicos:**
+- "Genera un pliego de licitación completo para servicios de mantenimiento de carreteras basado en licitaciones similares exitosas"
+- "Analiza las tendencias de precios del mercado para servicios de TI en municipios de tamaño similar"
+- "Crea las especificaciones técnicas para proyectos de alumbrado urbano utilizando las mejores prácticas de otras ciudades"
+- "Redacta los criterios de evaluación que cumplan con la ley de contratación pública española"
 
-- "Genera un borrador de hilo para redes sociales resumiendo la última reunión del pleno."
-- "Identifica fortalezas y debilidades en los argumentos de la oposición."
-- "Resume las quejas ciudadanas sobre la limpieza de calles."
-- "Analiza un documento de planificación extenso y extrae los 5 puntos más relevantes."
-- "Identifica menciones de 'impacto económico' y 'sostenibilidad' en los informes de festivales."
+**Para el Personal Municipal:**
 
-### Impacto económico y social
+- "Encuentra licitaciones similares de otros ayuntamientos para contratos de gestión de residuos"
+- "Analiza los requisitos de una licitación y sugiere mejoras basadas en adjudicaciones exitosas"
+- "Genera cronogramas de contratación que cumplan con los requisitos legales"
+- "Crea justificaciones presupuestarias utilizando datos municipales comparables"
 
-- **Cataluña**: 900+ municipios, más de 8.000 millones de euros de presupuesto anual. Incluso una adopción del 5% podría gestionar más de 400 millones de euros en recursos.
-- **Ahorros en eficiencia**: 2-5% de ahorro en presupuestos operativos, potencialmente 8-20 millones de euros optimizados anualmente en las primeras etapas.
-- **Escalabilidad**: Diseñado para España (8.000+ municipios, 60.000 millones de euros de presupuesto) y más allá, con planes para soporte multilingüe.
+**Características Clave:**
 
-## Arquitectura y stack tecnológico
+- **Integración Exhaustiva de Datos**: Accede a todas las licitaciones publicadas en los portales gubernamentales de España (PLACSP, plataformas autonómicas).
+- **Generación Inteligente de Documentos**: Crea pliegos de licitación conformes a la ley utilizando plantillas de éxito.
+- **Inteligencia de Mercado**: Proporciona información sobre precios y análisis de proveedores.
+- **Cumplimiento Legal**: Garantiza que todos los documentos cumplan con la normativa de contratación pública española.
 
-Aipacto está construido con una arquitectura moderna y robusta:
+### Impacto Económico y Social
 
-- **Clean Architecture y DDD**: El código está organizado en contextos delimitados, siguiendo principios de Clean Architecture y Domain-Driven Design para facilitar el mantenimiento y la escalabilidad.
-- **TypeScript en todo**: Desarrollo full stack y multiplataforma en TypeScript para mayor consistencia y seguridad.
-- **Frontend**: React, React Native, Expo, Tamagui (Material Design 3, tokens personalizados para el tema).
-- **Backend**: Fastify (Node.js), Effect, contenedores para computación segura.
-- **Orquestación IA**: LangChain, LangGraph para flujos de trabajo multiagente.
-- **Búsqueda semántica**: Qdrant.
-- **LLMs principales**: Modelos Salamandra de Aina Kit, con soporte para OpenAI, DeepSeek, Grok, etc.
-- **Almacenamiento de datos**: PostgreSQL, Databricks.
-- **Otras herramientas**: Procesamiento masivo de datos, búsqueda en internet, GitHub para colaboración open source.
+- **España**: Más de 8.000 municipios que gestionan más de 60.000 M€ en contratación anual. Incluso una adopción del 5% podría optimizar más de 3.000 M€ en gasto público.
+- **Eficiencia en la Contratación**: Reducir el tiempo de preparación de licitaciones en un 70%, mejorando al mismo tiempo la calidad y el cumplimiento normativo.
+- **Inteligencia de Mercado**: Facilitar mejores negociaciones de precios, con un ahorro potencial del 2-5% en contratos municipales.
+- **Escalabilidad**: Comenzando en España con planes de expansión a la UE, aprovechando las capacidades de IA multilingüe.
 
-## Componentes principales
+## Arquitectura y Stack Tecnológico
 
-1. **Interfaz de chat**: UI de chat multiplataforma (web/móvil) para consultar datos, generar información o solicitar acciones.
-2. **Rastreadores de datos**: Scripts para recopilar y estructurar datos regionales para su análisis.
-3. **Flujos de trabajo agentic**: Sistema multiagente orquestado mediante LangChain y LangGraph.
-4. **APIs backend**: Servidor Fastify que gestiona sesiones de chat, procesamiento de datos y tareas de agentes.
+Aipacto está construido con una arquitectura moderna y de nivel empresarial:
 
-## Cómo contribuir
+- **Arquitectura Limpia y DDD**: Organizado en contextos delimitados (*bounded contexts*) siguiendo los principios de Arquitectura Limpia y Diseño Guiado por el Dominio (*Domain-Driven Design*) para mantenibilidad y escalabilidad.
+- **TypeScript en todo el stack**: Desarrollo full-stack en TypeScript para consistencia, seguridad y productividad del desarrollador.
+- **Frontend**: React, React Native, Expo con Tamagui (Material Design 3) para aplicaciones municipales multiplataforma.
+- **Backend**: Fastify (Node.js), Effect para programación funcional, contenedorizado para un despliegue multi-tenant seguro.
+- **Orquestación de IA**: LangChain, LangGraph para flujos de trabajo multi-agente que procesan documentos de licitación y datos de contratación.
+- **Integración de Datos**: Rastreadores (*crawlers*) exhaustivos para los portales de licitación gubernamentales de España (PLACSP, plataformas autonómicas).
+- **Búsqueda y Analítica**: Qdrant para búsqueda semántica en documentos de licitación, PostgreSQL para datos estructurados.
+- **Soporte para LLMs**: Modelos optimizados para español con *fallback* a OpenAI, Claude y otros proveedores.
+- **Seguridad y Cumplimiento Normativo**: Diseñado para los requisitos del sector público con registros de auditoría y protección de datos.
 
-Estamos desarrollando activamente las interfaces web y móvil principales y el orquestador de agentes IA. Si te interesa tener un impacto significativo en la intersección de IA, gobernanza y open source, ¡nos encantaría contar contigo!
+## Componentes Principales
 
-Antes de empezar, por favor lee nuestra [Guía de contribución](../CONTRIBUTING.md) para instrucciones de configuración, estándares de código y flujo de trabajo de contribución.
+1. **Interfaz del Generador de Licitaciones**: Aplicación multiplataforma (web/móvil) para crear y gestionar documentos de contratación.
+2. **Rastreadores de Datos de Licitaciones de España**: Scripts automatizados para recopilar y estructurar datos de licitaciones de portales gubernamentales.
+3. **Agentes de IA para Contratación Pública**: Sistema multi-agente especializado en el análisis de licitaciones, generación de documentos y verificación del cumplimiento normativo.
+4. **APIs Municipales**: Servidor Fastify que gestiona los flujos de trabajo de contratación, el procesamiento de documentos y la inteligencia de licitaciones.
+
+## Cómo Colaborar
+
+Estamos desarrollando activamente la aplicación del generador de licitaciones y los agentes de IA para la contratación. Si te interesa revolucionar la contratación pública a través de la IA y hacer más eficientes las operaciones municipales, ¡nos encantaría que contribuyeras!
+
+Antes de empezar, por favor, lee nuestra [Guía de Contribución](../CONTRIBUTING.md) para ver las instrucciones de configuración, los estándares de codificación y el flujo de trabajo para las contribuciones.
 
 ## Licencia
 
-Licenciado bajo la Licencia MIT con una cláusula visible de atribución.
+Licencia GNU Affero General Public License v3.0.
 
-Cualquier uso público debe mostrar el texto "Powered by AIPacto.com".
-
-Consulta [LICENSE](../LICENSE) para más detalles.
+Consulta el archivo [LICENSE](../LICENSE) para ver todos los detalles.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,36 +7,36 @@ pre-commit:
           echo "Please use a feature branch and create a pull request."
           exit 1
         fi
-    secretlint:
-      run: |
-        echo "🔑 Running Secretlint..."
-        yarn secretlint "{staged_files}"
-      stage_fixed: false
-    generate-paths:
-      run: |
-        echo "🔄 Updating TypeScript paths..."
-        yarn generate-paths
-      stage_fixed: true
     check-deps:
       run: |
         echo "📦 Running dependency version consistency checks..."
         yarn check-deps
       stage_fixed: true
-    check-types:
+    secretlint:
       run: |
-        if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
-          echo "🔍 Running type checks..."
-          yarn check-types
-        else
-          echo "⏭️ Skipping type checks on non-main branch"
-        fi
-      stage_fixed: true
+        echo "🔑 Running Secretlint (staged files)..."
+        yarn secretlint "{staged_files}"
+      stage_fixed: false
     lint:
       run: |
         echo "✨ Running lint checks..."
-        yarn lint:syncpack && yarn lint:biome --staged --diagnostic-level=error
+        yarn lint
       stage_fixed: true
 
+# Prevent merge commits on main
+pre-merge-commit:
+  commands:
+    block-merge-on-main:
+      run: |
+        if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
+          echo "❌ Merge commits on 'main' branch are not allowed."
+          echo "Please use rebase or squash instead of merge."
+          echo "To rebase: git pull --rebase origin main"
+          echo "To squash: git pull --squash origin main"
+          exit 1
+        fi
+
+# Enforce branch policy and run tests
 pre-push:
   commands:
     block-main-push:
@@ -45,4 +45,22 @@ pre-push:
           echo "❌ Direct pushes to the 'main' branch are not allowed."
           echo "Please use a feature branch and create a pull request."
           exit 1
+        fi
+    block-merge-commits:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" = "main" ]; then
+          # Check for merge commits in the range to be pushed
+          merge_commits=$(git log origin/main..HEAD --merges --oneline)
+          if [ -n "$merge_commits" ]; then
+            echo "❌ Merge commits to 'main' are not allowed. Please use rebase or squash."
+            echo "Found merge commits:"
+            echo "$merge_commits"
+            echo ""
+            echo "To fix this:"
+            echo "1. git reset --soft origin/main"
+            echo "2. git commit -m 'Your commit message'"
+            echo "3. git push --force-with-lease origin main"
+            exit 1
+          fi
         fi


### PR DESCRIPTION
- Replaced the MIT License with the GNU Affero General Public License v3.0, ensuring compliance with open-source standards and community collaboration.
- Revised the contributing guide to align with the new project name "Aipacto" and included detailed setup instructions for a Nix-based development environment.
- Enhanced the guidelines on branching, PR workflow, and pre-commit checks to enforce best practices in code contributions.
- Updated README to reflect the project's vision, mission, and key features of the AI-powered tender writer application.